### PR TITLE
WBP-1955: remove migrateundlv action

### DIFF
--- a/include/orng.hpp
+++ b/include/orng.hpp
@@ -307,13 +307,6 @@ public:
     [[eosio::action]] void randnotify(uint64_t request_id, eosio::name dapp, uint64_t assoc_id, const eosio::checksum256 &rnd);
 
     /**
-     * Migrate entries from undelivered_old to undelivered table
-     * Sets free_call to false for all migrated entries
-     * @param batch_size Maximum number of entries to migrate in this call
-     */
-    [[eosio::action]] void migrateundlv(uint64_t batch_size);
-
-    /**
      * Configure adaptive staking parameters
      * @param total_capacity_calls_per_hr Total system capacity (calls/hour)
      * @param free_min_calls_per_hr Minimum free tier capacity (calls/hour)

--- a/src/orng.cpp
+++ b/src/orng.cpp
@@ -1160,46 +1160,6 @@ void orng::_cleanup_expired_results(uint64_t batch_size) {
     }
 }
 
-ACTION orng::migrateundlv(uint64_t batch_size) {
-    require_auth(get_self());
-    eosio::check(!is_paused(), "paused");
-
-    // Validate batch size to prevent timeout
-    check(batch_size > 0 && batch_size <= 100, "batch size must be between 1 and 100");
-
-    // Open both old and new tables
-    undelivered_table_type_old old_table(get_self(), get_self().value);
-    undelivered_table_type new_table(get_self(), get_self().value);
-
-    uint64_t migrated = 0;
-    auto it = old_table.begin();
-
-    while (it != old_table.end() && migrated < batch_size) {
-        // Check if entry already exists in new table
-        auto new_it = new_table.find(it->request_id);
-
-        if (new_it == new_table.end()) {
-            // Copy to new table with free_call set to false
-            new_table.emplace(get_self(), [&](auto& row) {
-                row.request_id = it->request_id;
-                row.dapp = it->dapp;
-                row.assoc_id = it->assoc_id;
-                row.rnd = it->rnd;
-                row.error_message = it->error_message;
-                row.oracle_reward_deadline = it->oracle_reward_deadline;
-                row.free_call = false; // Set default to false
-            });
-        }
-
-        // Erase from old table
-        it = old_table.erase(it);
-        migrated++;
-    }
-
-    // Log migration result
-    check(migrated > 0, "no entries to migrate");
-}
-
 bool orng::can_use_legacy_callback(eosio::name dapp) {
     // Check if dapp exists in legacy callback table
     auto legacy_it = legacycallback_table.find(dapp.value);


### PR DESCRIPTION
## What
Removes the one-time `migrateundlv` action. The `undelivered_old` → `undelivered1` migration is complete, so the action is dead code; removing it shrinks the contract's public action surface.

## Scope
- Removed the `migrateundlv` action declaration (`include/orng.hpp`) and implementation (`src/orng.cpp`).
- **Kept** the `undelivered_old` table type: it still carries the `[[eosio::table]]` ABI entry for the legacy on-chain `undelivered` table. Dropping that table from the ABI is a separate data-migration decision (any residual rows would need draining first) and is intentionally out of scope.

## Verification
- Builds clean via `make docker-build` (CDT). Regenerated ABI no longer lists `migrateundlv`; `undelivered`/`undelivered1` tables and all other actions retained (34 actions).

## Downstream
The `wax-rng-oracle` integration test fixture (`test/artifacts/wax.orng.{abi,wasm}`) will be synced to this build — see the companion oracle PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)