### PR TITLE
chore: bump to 3.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wax-orng",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wax-orng",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "ISC",
       "dependencies": {
         "@waxio/vert": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wax-orng",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "- Is open source and is a blockchain-native service that developers can easily integrate into their dApps. - Is based on the [Signidice algorithm](https://github.com/gluk256/misc/blob/master/rng4ethereum/signidice.md) and RSA verification. Signidice was chosen for its excellent randomization and non-gameablity characteristics, in addition to yielding a cleaner workflow for dApp developers and being provably fair. RSA verification ensures uniqueness of the signature and removes the ability for the results to be manipulated (if any other type of signing algorithm were used, it would allow many valid signatures for the same signing_value which could result in manipulation). - Can easily be established as provably fair. The self-verifying WAX RNG Native Blockchain Service confirms that the RSA signature that comes back from the WAX RNG oracle is valid and authentic before being utilized by the dApp. When dApp customers can easily establish fairness, they have a higher degree of confidence in using the dApp.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Release marker for the `migrateundlv` removal (WBP-1955, #83).

Patch bump (3.2.0 → 3.2.1): dead-code cleanup with no behavior change for callers. Bumps `package.json` + `package-lock.json`, matching the repo's release convention (followed by a `v3.2.1` tag on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)